### PR TITLE
Upgrade superset to version 1.5.0

### DIFF
--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/python-38:1-86
 
 # Superset version
-ARG SUPERSET_VERSION=1.4.1
+ARG SUPERSET_VERSION=1.5.0
 
 # Configure environment
 ENV GUNICORN_BIND=0.0.0.0:8088 \

--- a/superset/Makefile
+++ b/superset/Makefile
@@ -1,4 +1,4 @@
-SUPERSET_VERSION=1.4.1-ubi
+SUPERSET_VERSION=1.5.0-ubi
 IMAGE_NAME=quay.io/opendatahub/superset:${SUPERSET_VERSION}
 
 BUILDER:=$(shell command -v podman 2> /dev/null || command -v docker 2> /dev/null || echo "docker or podman not found")


### PR DESCRIPTION
## Description
Update the superset image build to version 1.5.0

## How Has This Been Tested?
I deployed superset in a development OC 4.11 cluster from the current version (1.4.1) then updated the deployment to use this new image. All Superset functionality continued working as normal.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
